### PR TITLE
fix: change body classes

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,30 +1,7 @@
 <!doctype html>
 <html lang="{{ .Site.LanguageCode | default "en" }}">
   {{ partial "head/head.html" . }}
-
-  {{ $template := "" }}
-  {{ if or (eq .Kind "404") (eq .Kind "page") (eq .Kind "home")}}
-    {{ $template = "single" }}
-  {{ else if or (eq .Kind "section") (eq .Kind "taxonomy") (eq .Kind "term") -}}
-    {{ $template = "list" }}
-  {{ end -}}
-
-  {{ $name := "" }}
-  {{ if eq .Kind "taxonomy" }}
-    {{ $name = printf "taxonomy %s" .Data.Plural }}
-  {{ else if eq .Kind "term" }}
-    {{ $name = printf "term %s" .Section}}
-  {{ else if .Section }}
-    {{ $name = printf "section %s" .Section }}
-  {{ else if eq .Kind "page" }}
-    {{ $name = .File.ContentBaseName }}
-  {{ else if eq .Kind "home" }}
-    {{ $name = "home" }}
-  {{ else if eq .Kind "404" }}
-    {{ $name = "error404" }}
-  {{ end }}
-
-  {{ .Scratch.Set "class" (slice $template $name) -}}
+  {{- partial "head/body-class.html" -}}
   <body class="{{ delimit (.Scratch.Get "class") " " }}">
     {{ if and .IsHome .Site.Params.alert }}
       {{ partial "header/alert.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="{{ .Site.LanguageCode | default "en" }}">
   {{ partial "head/head.html" . }}
-  {{- partial "head/body-class.html" -}}
+  {{- partial "head/body-class.html" . -}}
   <body class="{{ delimit (.Scratch.Get "class") " " }}">
     {{ if and .IsHome .Site.Params.alert }}
       {{ partial "header/alert.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,18 +1,18 @@
 <!doctype html>
 <html lang="{{ .Site.LanguageCode | default "en" }}">
   {{ partial "head/head.html" . }}
-  {{ if eq .Kind "home" -}}
-    {{ .Scratch.Set "class" "home" -}}
-  {{ else if eq .Kind "404" -}}
-    {{ .Scratch.Set "class" "error404" -}}
-  {{ else if eq .Kind "page" -}}
-    {{ .Scratch.Set "class" .Type -}}
-    {{ .Scratch.Add "class" " single" -}}
-  {{ else -}}
-    {{ .Scratch.Set "class" .Type -}}
-    {{ .Scratch.Add "class" " list" -}}
+  {{ $template := "" }}
+  {{ $type := "default" }}
+  {{ if ne .Type "page" }}
+    {{ $type = .Type }}
+  {{ end }}
+  {{ if or (eq .Kind "404") (eq .Kind "page") }}
+    {{ $template = "single" }}
+  {{ else if or (eq .Kind "section") (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm") -}}
+    {{ $template = "list" }}
   {{ end -}}
-  <body class="{{ .Scratch.Get "class" }}">
+  {{ .Scratch.Set "class" (slice .Kind $template $type) -}}
+  <body class="{{ delimit (.Scratch.Get "class") " " }}">
     {{ if and .IsHome .Site.Params.alert }}
       {{ partial "header/alert.html" . }}
     {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,17 +1,30 @@
 <!doctype html>
 <html lang="{{ .Site.LanguageCode | default "en" }}">
   {{ partial "head/head.html" . }}
+
   {{ $template := "" }}
-  {{ $type := "default" }}
-  {{ if ne .Type "page" }}
-    {{ $type = .Type }}
-  {{ end }}
-  {{ if or (eq .Kind "404") (eq .Kind "page") }}
+  {{ if or (eq .Kind "404") (eq .Kind "page") (eq .Kind "home")}}
     {{ $template = "single" }}
-  {{ else if or (eq .Kind "section") (eq .Kind "taxonomy") (eq .Kind "taxonomyTerm") -}}
+  {{ else if or (eq .Kind "section") (eq .Kind "taxonomy") (eq .Kind "term") -}}
     {{ $template = "list" }}
   {{ end -}}
-  {{ .Scratch.Set "class" (slice .Kind $template $type) -}}
+
+  {{ $name := "" }}
+  {{ if eq .Kind "taxonomy" }}
+    {{ $name = printf "taxonomy %s" .Data.Plural }}
+  {{ else if eq .Kind "term" }}
+    {{ $name = printf "term %s" .Section}}
+  {{ else if .Section }}
+    {{ $name = printf "section %s" .Section }}
+  {{ else if eq .Kind "page" }}
+    {{ $name = .File.ContentBaseName }}
+  {{ else if eq .Kind "home" }}
+    {{ $name = "home" }}
+  {{ else if eq .Kind "404" }}
+    {{ $name = "error404" }}
+  {{ end }}
+
+  {{ .Scratch.Set "class" (slice $template $name) -}}
   <body class="{{ delimit (.Scratch.Get "class") " " }}">
     {{ if and .IsHome .Site.Params.alert }}
       {{ partial "header/alert.html" . }}

--- a/layouts/partials/head/body-class.html
+++ b/layouts/partials/head/body-class.html
@@ -1,0 +1,21 @@
+{{- $template := "" -}}
+{{- if or (eq .Kind "404") (eq .Kind "page") (eq .Kind "home") -}}
+  {{ $template = "single" -}}
+{{- else if or (eq .Kind "section") (eq .Kind "taxonomy") (eq .Kind "term") -}}
+  {{ $template = "list" -}}
+{{- end -}}
+{{- $name := "" -}}
+{{- if eq .Kind "taxonomy" -}}
+  {{- $name = printf "taxonomy %s" .Data.Plural -}}
+{{- else if eq .Kind "term" -}}-
+  {{- $name = printf "term %s" .Section -}}
+{{- else if .Section -}}
+  {{- $name = printf "section %s" .Section -}}
+{{- else if eq .Kind "page" -}}
+  {{- $name = .File.ContentBaseName -}}
+{{- else if eq .Kind "home" -}}
+  {{- $name = "home" -}}
+{{- else if eq .Kind "404" -}}
+  {{- $name = "error404" -}}
+{{- end -}}
+{{- .Scratch.Set "class" (slice $template $name) -}}


### PR DESCRIPTION
This PR does include some breaking changes which you may want to consider if you are interested in the way that I generate classes for the body, from HUGO.

I have moved to slice arrays so spaces are not necessary.

As .Kind and .Type can both return "page" I have assigned the value of "default" to the .Type of "page", as this matches single.html and list.html in the layout/_default directory

My goal is to target classes based on the file structure of a hugo document, and stay as close to what is returned from the .Kind and .Type variables.

Some example outputs

.Kind        $template    .Type (page = default)
home                         default
page                single default
page                single contact
404                  single default
section              list     default
section              list     products
taxonomy         list     categories ??
taxonomyTerm list     category ??

I don't have experience with taxonomy/taxonomyTerm use cases so I put question marks there.

Any ideas? I have messed with Hugo's structure by changing .Type of "page" to "default" so I am looking for some feedback whether you would like to include this or not.

