### PR TITLE
Libsass

### DIFF
--- a/layouts/partials/head/libsass.html
+++ b/layouts/partials/head/libsass.html
@@ -1,0 +1,10 @@
+{{ if eq (hugo.Environment) "development" -}}
+  {{ $options := (dict "targetPath" "main.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
+  {{ $css := resources.Get . | toCSS $options -}}
+  <link rel="stylesheet" href="{{ $css.Permalink }}">
+{{ else -}}
+  {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
+  {{ $css := resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") -}}
+  {{ $secureCSS := $css | resources.Fingerprint "sha512" -}}
+  <link rel="stylesheet" href="{{ $secureCSS.Permalink }}" integrity="{{ $secureCSS.Data.Integrity }}" crossorigin="anonymous">
+{{ end -}}

--- a/layouts/partials/head/libsass.html
+++ b/layouts/partials/head/libsass.html
@@ -1,10 +1,9 @@
+{{ $css := "" }}
 {{ if eq (hugo.Environment) "development" -}}
-  {{ $options := (dict "targetPath" "main.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get . | toCSS $options -}}
-  <link rel="stylesheet" href="{{ $css.Permalink }}">
+  {{ $options := (dict "transpiler" "libsass" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
+  {{ $css = resources.Get . | toCSS $options | resources.Fingerprint "sha512" -}}
 {{ else -}}
-  {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") -}}
-  {{ $secureCSS := $css | resources.Fingerprint "sha512" -}}
-  <link rel="stylesheet" href="{{ $secureCSS.Permalink }}" integrity="{{ $secureCSS.Data.Integrity }}" crossorigin="anonymous">
+  {{ $options := (dict "transpiler" "libsass" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
+  {{ $css = resources.Get . | toCSS $options | postCSS (dict "config" "config/postcss.config.js") | resources.Fingerprint "sha512" -}}
 {{ end -}}
+<link rel="stylesheet" href="{{ $css.Permalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">

--- a/layouts/partials/head/stylesheet.html
+++ b/layouts/partials/head/stylesheet.html
@@ -1,11 +1,2 @@
-{{ if eq (hugo.Environment) "development" -}}
-  {{ $options := (dict "targetPath" "main.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get "scss/app.scss" | toCSS $options -}}
-  <link rel="stylesheet" href="{{ $css.Permalink }}">
-{{ else -}}
-  {{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "includePaths" (slice "node_modules")) -}}
-  {{ $css := resources.Get "scss/app.scss" | toCSS $options | postCSS (dict "config" "config/postcss.config.js") -}}
-  {{ $secureCSS := $css | resources.Fingerprint "sha512" -}}
-  <link rel="stylesheet" href="{{ $secureCSS.Permalink }}" integrity="{{ $secureCSS.Data.Integrity }}" crossorigin="anonymous">
-{{ end -}}
+{{ partial "head/libsass" "scss/app.scss"}}
 <noscript><style>img.lazyload { display: none; }</style></noscript>


### PR DESCRIPTION
Move sass/scss compilation into a partial so that there is the option of splitting the css file. 

Both dev and prod have css hash for cache busting. 

transpiler = libass was added to avoid breaking changes if hugo changes to dartsass

targetPath was removed but could be added as an option.