### PR TITLE
Remove "shrink-to-fit=no"

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ block "head/resource-hints" . }}{{ partial "head/resource-hints.html" . }}{{ end }}
   {{ block "head/stylesheet" . }}{{ partial "head/stylesheet.html" . }}{{ end }}
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}


### PR DESCRIPTION
This is no longer needed. See [here](https://www.scottohara.me/blog/2018/12/11/shrink-to-fit.html) for more details.
>Since posting the results of my testing, and using the results as references for pull requests, HTML5 Boilerplate and Josh Buchea’s HEAD repository have accepted the removal of shrink-to-fit=no from their recommended viewport meta tags.

>Speaking of the HEAD repository, Josh Buchea pointed me to these additional stats on iOS usage, indicating that iOS 9.0-9.2.x usage is currently at 0.17%. If these numbers are truly indicative of global use of these versions, then it’s even more likely to be safe to remove shrink-to-fit from your viewport meta tag.