### PR TITLE
Better image support 

### DIFF
--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -1,5 +1,19 @@
 figure {
-  margin: 2rem 0;
+  margin: 0 0 1rem;
+  display: inline-block;
+}
+
+figure img {
+  margin-bottom: 0.5rem;
+  line-height: 1;
+  max-width: 100%;
+  height: auto;
+}
+
+figure figcaption {
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.875em;
+  color: #6c757d;
 }
 
 .figure-caption {

--- a/config/_default/module.toml
+++ b/config/_default/module.toml
@@ -1,0 +1,7 @@
+[[mounts]]
+  source = "layouts"
+  target = "layouts"
+
+[[mounts]]
+  source = "node_modules/@hyas/images/layouts"
+  target = "layouts"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -37,13 +37,20 @@ schemaGitHub = "https://github.com/h-enk/hyas"
 ## Chrome Browser
 themeColor = "#fff"
 
-# Images
+# Images - Temporarily left in place for backward compatibility
 quality = 85
 bgColor = "#fff"
 landscapePhotoWidths = [900, 800, 700, 600, 500]
 portraitPhotoWidths = [800, 700, 600, 500]
 lqipWidth = "20x"
 smallLimit = "320"
+
+# Images
+imageResponsive = true
+imageConvertTo = "webp"
+imageImageSizes = ["480","720","1080","1280","1600","2048"]
+singleSize = false
+imageAddClass = "img-fluid lazyload blur-up"
 
 ### Image template
 defaultImage = "default-image.png" # put in `./assets/images/`

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,3 +1,5 @@
+{{/* Temporarily left in place for backward compatibility */}}
+
 {{ $image := "" -}}
 {{ if (urls.Parse .Destination).IsAbs }}
   {{ $image = resources.GetRemote .Destination -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/core": "^7.18",
         "@babel/preset-env": "^7.18",
         "@fullhuman/postcss-purgecss": "^4.1",
+        "@hyas/images": "^0.2.1",
         "@popperjs/core": "^2.11",
         "auto-changelog": "^2.4",
         "autoprefixer": "^10.4",
@@ -1749,6 +1750,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@hyas/images": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.1.tgz",
+      "integrity": "sha512-OESrxH316UeTbgpDJsRS1fnoZzOIGh2+evhaaXUBrDXhg+5YT1myR7SKf00bzi1fSbQlw5+JyOmNLll/JNHxoQ==",
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -8203,6 +8210,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@hyas/images": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@hyas/images/-/images-0.2.1.tgz",
+      "integrity": "sha512-OESrxH316UeTbgpDJsRS1fnoZzOIGh2+evhaaXUBrDXhg+5YT1myR7SKf00bzi1fSbQlw5+JyOmNLll/JNHxoQ==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "^7.18",
     "@babel/preset-env": "^7.18",
     "@fullhuman/postcss-purgecss": "^4.1",
+    "@hyas/images": "^0.2.1",
     "@popperjs/core": "^2.11",
     "auto-changelog": "^2.4",
     "autoprefixer": "^10.4",


### PR DESCRIPTION
## Summary

- Supports remote images + local images in [page bundle](https://gohugo.io/content-management/page-bundles/) or`./assets` directory
- Supported types: png, jpeg/jpg, tif/tiff, bmp, gif, and webp
- All images are responsive + converted to webp per default
- Supports data:image... in src intead of a URL

## Usage

### Markdown

```md
![Alt tag](image003.png "Optional title tag")
```

### Shortcode

```md
{{< figure src="screenshot.png" alt="Screenshot of a web page with an aqua theme" caption="For a figure caption can be different than alt text" >}}
```

## Credits

Based on [DFD Hugo image handling module](https://github.com/danielfdickinson/image-handling-mod-hugo-dfd) by [Daniel F. Dickinson](https://github.com/danielfdickinson)

## Implementation

The image functionality is made available as npm package [@hyas/images](https://www.npmjs.com/package/@hyas/images)

## TODO

Part of [h-enk/hyas-images](https://github.com/h-enk/hyas-images/issues):

- [ ] Add LQIP support
- [ ] Add `imageConvertMethod` as an option — think `[ Fit | GrowFit | Fill | Resize ]`
